### PR TITLE
Fix for an exception when autocreate was used with group mapping

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -32,7 +32,8 @@
 		"UserLogoutComplete": "PluggableAuthHooks::deauthenticate",
 		"AuthChangeFormFields": "PluggableAuthHooks::onAuthChangeFormFields",
 		"PersonalUrls": "PluggableAuthHooks::modifyLoginURLs",
-		"BeforeInitialize": "PluggableAuthHooks::doBeforeInitialize"
+		"BeforeInitialize": "PluggableAuthHooks::doBeforeInitialize",
+		"LocalUserCreated": "PluggableAuthHooks::onLocalUserCreated"
 	},
 	"AuthManagerAutoConfig": {
 		"primaryauth": {

--- a/includes/PluggableAuthHooks.php
+++ b/includes/PluggableAuthHooks.php
@@ -158,4 +158,20 @@ class PluggableAuthHooks {
 			unset( $personal_urls['logout'] );
 		}
 	}
+
+	/**
+	 * Populate groups after the local user is created
+	 * See https://www.mediawiki.org/wiki/Manual:Hooks/LocalUserCreated
+	 * Called immediately after a local user has been created and saved to the database
+	 *
+	 * @param User $user current user
+	 * @param bool $autocreated whether the user was autocreated
+	 */
+	public static function onLocalUserCreated(
+		User $user, $autocreated
+	) {
+		if ( $autocreated ) {
+			Hooks::run( 'PluggableAuthPopulateGroups', [ $user ] );
+		}
+	}
 }

--- a/includes/PluggableAuthLogin.php
+++ b/includes/PluggableAuthLogin.php
@@ -37,8 +37,8 @@ class PluggableAuthLogin extends UnlistedSpecialPage {
 					$user->mId = $id;
 					$user->loadFromId();
 					wfDebug( 'Authenticated existing user: ' . $user->mName );
+					Hooks::run( 'PluggableAuthPopulateGroups', [ $user ] );
 				}
-				Hooks::run( 'PluggableAuthPopulateGroups', [ $user ] );
 				$authorized = true;
 				Hooks::run( 'PluggableAuthUserAuthorization', [ $user, &$authorized ] );
 				if ( $authorized ) {


### PR DESCRIPTION
An exception was thrown when a wiki group was assigned to a new local wiki user. If user id = 0 addgroup and removegroup failed.

Now PluggableAuthPopulateGroups runs after the new local user is created and after an existing user login.